### PR TITLE
Use editor debug component instead of duplicated code (see GN-3152)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3266,9 +3266,9 @@
       "dev": true
     },
     "@lblod/ember-rdfa-editor": {
-      "version": "0.50.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-0.50.0-beta.5.tgz",
-      "integrity": "sha512-Jpp2kaQnxZin6DuUnKQiT1166NXfqjgVUuSMqoarOSotCwzaq1PXhC8Q29STyuIcaVxHUC3aTG5vcczcy6Crng==",
+      "version": "0.50.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-0.50.0-beta.6.tgz",
+      "integrity": "sha512-0lQXFQKCcRUQIzQug4uQ+0MkJn92dJznERCKMGesyjLUKtFujQINfTlTmvorbK7Sj1rjF/Jju6aPn9A5Di+JHQ==",
       "dev": true,
       "requires": {
         "@ember/optional-features": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2882,12 +2882,12 @@
       }
     },
     "@formatjs/ecma402-abstract": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.0.tgz",
-      "integrity": "sha512-TOp5La9wmSh9G5bqFGN/ApmOXtJDzBGkYW+OTRd3ukY7J32RVGZPpN4O9BD651JUy66nj3g9CIENTNCgm4IRXQ==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.2.tgz",
+      "integrity": "sha512-qDgOL0vtfJ51cc0pRbFB/oXc4qDbamG22Z6h/QWy6FBxaQgppiy8JF0iYbmNO35cC8r88bQGsgfd/eM6/eTEQQ==",
       "dev": true,
       "requires": {
-        "@formatjs/intl-localematcher": "0.2.21",
+        "@formatjs/intl-localematcher": "0.2.23",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -2900,9 +2900,9 @@
       }
     },
     "@formatjs/fast-memoize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.0.tgz",
-      "integrity": "sha512-fObitP9Tlc31SKrPHgkPgQpGo4+4yXfQQITTCNH8AZdEqB7Mq4nPrjpUL/tNGN3lEeJcFxDbi0haX8HM7QvQ8w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz",
+      "integrity": "sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==",
       "dev": true,
       "requires": {
         "tslib": "^2.1.0"
@@ -2917,13 +2917,13 @@
       }
     },
     "@formatjs/icu-messageformat-parser": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.0.15.tgz",
-      "integrity": "sha512-nnRbkK+nz4ZL1l1lUbztL8qrEUGQKF/NU38itLnzLm8QLEacFS5qGOxxp/0DSIehhX99tNroNtudtjdOvzruAQ==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.0.17.tgz",
+      "integrity": "sha512-GO4DzmyiDUyT4p9UxSlOcdnRL1CCt43oHBBGe21s5043UjP6dwMbOotugKs1bRiN+FrNrRUSW+TLdT3+4CBI5A==",
       "dev": true,
       "requires": {
-        "@formatjs/ecma402-abstract": "1.11.0",
-        "@formatjs/icu-skeleton-parser": "1.3.2",
+        "@formatjs/ecma402-abstract": "1.11.2",
+        "@formatjs/icu-skeleton-parser": "1.3.4",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -2936,12 +2936,12 @@
       }
     },
     "@formatjs/icu-skeleton-parser": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.2.tgz",
-      "integrity": "sha512-ChKmnVCE/LbJzedRgA/EeL5+tfjx/6ZWunqNiEC5BtqHnnwmLN/oPuCPb8b3NhuGiwTqp+LkaS70tga5kXRHxg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.4.tgz",
+      "integrity": "sha512-BbKjX3rF3hq2bRjI9NjnSPUrNqI1TwwbMomOBamWfAkpOEf4LYEezPL9tHEds/+sN2/82Z+qEmK7s/l9G2J+qA==",
       "dev": true,
       "requires": {
-        "@formatjs/ecma402-abstract": "1.11.0",
+        "@formatjs/ecma402-abstract": "1.11.2",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -2954,9 +2954,9 @@
       }
     },
     "@formatjs/intl-localematcher": {
-      "version": "0.2.21",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.21.tgz",
-      "integrity": "sha512-JTJeLiNwexN4Gy0cMxoUPvJbKhXdnSuo5jPrDafEZpnDWlJ5VDYta8zUVVozO/pwzEmFVHEUpgiEDj+39L4oMg==",
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.23.tgz",
+      "integrity": "sha512-oCe2TOciTtB1bEbJ85EvYrXQxD0epusmVJfJ7AduO0tlbXP42CmDIYIH2CZ+kP2GE+PTLQD1Hbt9kpOpl939MQ==",
       "dev": true,
       "requires": {
         "tslib": "^2.1.0"
@@ -3266,9 +3266,9 @@
       "dev": true
     },
     "@lblod/ember-rdfa-editor": {
-      "version": "0.50.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-0.50.0-beta.2.tgz",
-      "integrity": "sha512-ZCgFoGThihMJpKMH58s0HgN+lVcJHBz3tvFTizZTVSwUvs8TlWVZSQm1cjgaxF01PRpk8rWDdt+IWY526lA4+A==",
+      "version": "0.50.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-0.50.0-beta.5.tgz",
+      "integrity": "sha512-Jpp2kaQnxZin6DuUnKQiT1166NXfqjgVUuSMqoarOSotCwzaq1PXhC8Q29STyuIcaVxHUC3aTG5vcczcy6Crng==",
       "dev": true,
       "requires": {
         "@ember/optional-features": "^2.0.0",
@@ -3298,8 +3298,7 @@
         "mdn-polyfills": "^5.16.0",
         "rdf-data-factory": "^1.1.0",
         "relative-to-absolute-iri": "^1.0.6",
-        "stream-browserify": "^3.0.0",
-        "xml-formatter": "^2.4.0"
+        "stream-browserify": "^3.0.0"
       },
       "dependencies": {
         "debug": {
@@ -3327,18 +3326,6 @@
             "semver": "^7.3.2",
             "stagehand": "^1.0.0",
             "walk-sync": "^2.2.0"
-          }
-        },
-        "ember-maybe-import-regenerator": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ember-maybe-import-regenerator/-/ember-maybe-import-regenerator-1.0.0.tgz",
-          "integrity": "sha512-wtjgjEV0Hk4fgiAwFjOfPrGWfmFrbRW3zgNZO4oA3H5FlbMssMvWuR8blQ3QSWYHODVK9r+ThsRAs8lG4kbxqA==",
-          "dev": true,
-          "requires": {
-            "broccoli-funnel": "^2.0.1",
-            "broccoli-merge-trees": "^3.0.0",
-            "ember-cli-babel": "^7.26.6",
-            "regenerator-runtime": "^0.13.2"
           }
         },
         "execa": {
@@ -3399,23 +3386,6 @@
             "path-key": "^3.0.0"
           }
         },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
-        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -3423,25 +3393,6 @@
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
-          }
-        },
-        "stream-browserify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
-          "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
-          "dev": true,
-          "requires": {
-            "inherits": "~2.0.4",
-            "readable-stream": "^3.5.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.2.0"
           }
         },
         "universalify": {
@@ -9148,9 +9099,9 @@
       }
     },
     "dompurify": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.3.tgz",
-      "integrity": "sha512-dqnqRkPMAjOZE0FogZ+ceJNM2dZ3V/yNOuFB7+39qpO93hHhfRpHw3heYQC7DPK9FqbQTfBKUJhiSfz4MvXYwg==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.5.tgz",
+      "integrity": "sha512-kD+f8qEaa42+mjdOpKeztu9Mfx5bv9gVLO6K9jRx4uGvh6Wv06Srn4jr1wPNY2OOUGGSKHNFN+A8MA3v0E0QAQ==",
       "dev": true
     },
     "dot-case": {
@@ -12396,9 +12347,9 @@
       }
     },
     "ember-intl": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/ember-intl/-/ember-intl-5.7.0.tgz",
-      "integrity": "sha512-NcQFPeV9wxyOX7Tb0y+84CXHPt5XleYUlszywx5aQgJQ4yE6in3kHjI804CRKtLz6OY0rzVfTa5Jc/y8CtI+0Q==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ember-intl/-/ember-intl-5.7.2.tgz",
+      "integrity": "sha512-gs17uY1ywzMaUpx1gxfBkFQYRTWTSa/zbkL13MVtffG9aBLP+998MibytZOUxIipMtLCm4sr/g6/1aaKRr9/+g==",
       "dev": true,
       "requires": {
         "broccoli-caching-writer": "^3.0.3",
@@ -12427,10 +12378,54 @@
         "silent-error": "^1.1.1"
       },
       "dependencies": {
+        "@embroider/shared-internals": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-1.0.0.tgz",
+          "integrity": "sha512-Vx3dmejJxI5MG/qC7or3EUZY0AZBSBNOAR50PYotX3LxUSb4lAm5wISPnFbwEY4bbo2VhL/6XtWjMv8ZMcaP+g==",
+          "dev": true,
+          "requires": {
+            "babel-import-util": "^1.1.0",
+            "ember-rfc176-data": "^0.3.17",
+            "fs-extra": "^9.1.0",
+            "lodash": "^4.17.21",
+            "resolve-package-path": "^4.0.1",
+            "semver": "^7.3.5",
+            "typescript-memoize": "^1.0.1"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "9.1.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+              "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+              "dev": true,
+              "requires": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+              }
+            },
+            "resolve-package-path": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
+              "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
+              "dev": true,
+              "requires": {
+                "path-root": "^0.1.1"
+              }
+            }
+          }
+        },
         "acorn": {
           "version": "6.4.2",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
           "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+          "dev": true
+        },
+        "babel-import-util": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-1.1.0.tgz",
+          "integrity": "sha512-sfzgAiJsUT1es9yrHAuJZuJfBkkOE7Og6rovAIwK/gNJX6MjDfWTprbPngdJZTd5ye4F3FvpvpQmvKXObRzVYA==",
           "dev": true
         },
         "broccoli-funnel": {
@@ -12483,16 +12478,16 @@
           }
         },
         "ember-auto-import": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-1.12.0.tgz",
-          "integrity": "sha512-fzMGnyHGfUNFHchpLbJ98Vs/c5H2wZBMR9r/XwW+WOWPisZDGLUPPyhJQsSREPoUQ+o8GvyLaD/rkrKqW8bmgw==",
+          "version": "1.12.1",
+          "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-1.12.1.tgz",
+          "integrity": "sha512-Jm0vWKNAy/wYMrdSQIrG8sRsvarIRHZ2sS/CGhMdMqVKJR48AhGU7NgPJ5SIlO/+seL2VSO+dtv7aEOEIaT6BA==",
           "dev": true,
           "requires": {
             "@babel/core": "^7.1.6",
             "@babel/preset-env": "^7.10.2",
             "@babel/traverse": "^7.1.6",
             "@babel/types": "^7.1.6",
-            "@embroider/core": "^0.33.0",
+            "@embroider/shared-internals": "^1.0.0",
             "babel-core": "^6.26.3",
             "babel-loader": "^8.0.6",
             "babel-plugin-syntax-dynamic-import": "^6.18.0",
@@ -12596,22 +12591,6 @@
                 "jsonfile": "^6.0.1",
                 "universalify": "^2.0.0"
               }
-            },
-            "jsonfile": {
-              "version": "6.1.0",
-              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-              "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.6",
-                "universalify": "^2.0.0"
-              }
-            },
-            "universalify": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-              "dev": true
             }
           }
         },
@@ -12641,6 +12620,23 @@
             "graceful-fs": "^4.1.2",
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
+          },
+          "dependencies": {
+            "jsonfile": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+              "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.6"
+              }
+            },
+            "universalify": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+              "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+              "dev": true
+            }
           }
         },
         "fs-tree-diff": {
@@ -12654,6 +12650,16 @@
             "object-assign": "^4.1.0",
             "path-posix": "^1.0.0",
             "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
           }
         },
         "matcher-collection": {
@@ -12740,6 +12746,12 @@
           "requires": {
             "safe-buffer": "~5.1.0"
           }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
         },
         "walk-sync": {
           "version": "2.2.0",
@@ -18176,14 +18188,14 @@
       }
     },
     "intl-messageformat": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.10.0.tgz",
-      "integrity": "sha512-OTOLlGPfwbrFyYD2iQuDbqEs8xccyLy+f1P3ZGJB2/EZo7Z9fVaaIWcM+JGvuWIFVRDnw4Um6z4t0mSSitUxGQ==",
+      "version": "9.11.3",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.11.3.tgz",
+      "integrity": "sha512-sFOaEw2cytBASTsJkfVod8IJzTx9oOPdU0C7jzprfGATn22FjQGJ60UCyCkKJo6UW+NnpKpwBjO73Pnhvv6HHg==",
       "dev": true,
       "requires": {
-        "@formatjs/ecma402-abstract": "1.11.0",
-        "@formatjs/fast-memoize": "1.2.0",
-        "@formatjs/icu-messageformat-parser": "2.0.15",
+        "@formatjs/ecma402-abstract": "1.11.2",
+        "@formatjs/fast-memoize": "1.2.1",
+        "@formatjs/icu-messageformat-parser": "2.0.17",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -19954,6 +19966,16 @@
                 "safe-buffer": "~5.1.0"
               }
             }
+          }
+        },
+        "stream-browserify": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+          "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+          "dev": true,
+          "requires": {
+            "inherits": "~2.0.1",
+            "readable-stream": "^2.0.2"
           }
         },
         "string_decoder": {
@@ -29074,37 +29096,39 @@
       "dev": true
     },
     "stream-browserify": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
-      "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "^2.0.2"
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
       },
       "dependencies": {
         "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        },
         "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "~5.2.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ember-concurrency": "2.x",
     "@appuniversum/appuniversum": "^0.2.1",
     "@appuniversum/ember-appuniversum": "^0.7.0",
-    "@lblod/ember-rdfa-editor": "^0.50.0-beta.5"
+    "@lblod/ember-rdfa-editor": "^0.50.0-beta.6"
   },
   "devDependencies": {
     "@appuniversum/appuniversum": "^0.2.1",
@@ -52,7 +52,7 @@
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "@lblod/ember-rdfa-editor-besluit-plugin": "~0.1.0",
-    "@lblod/ember-rdfa-editor": "^0.50.0-beta.5",
+    "@lblod/ember-rdfa-editor": "^0.50.0-beta.6",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~3.24.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ember-concurrency": "2.x",
     "@appuniversum/appuniversum": "^0.2.1",
     "@appuniversum/ember-appuniversum": "^0.7.0",
-    "@lblod/ember-rdfa-editor": "^0.50.0-beta.2"
+    "@lblod/ember-rdfa-editor": "0.50.0-beta.4"
   },
   "devDependencies": {
     "@appuniversum/appuniversum": "^0.2.1",
@@ -51,7 +51,7 @@
     "@ember/test-helpers": "^2.1.4",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
-    "@lblod/ember-rdfa-editor": "^0.50.0-beta.2",
+    "@lblod/ember-rdfa-editor-besluit-plugin": "~0.1.0",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~3.24.0",
@@ -91,7 +91,7 @@
     "sass": "^1.39.0",
     "webpack": "^5.58.2",
     "xml-formatter": "^2.5.0",
-    "@lblod/ember-rdfa-editor-besluit-plugin": "~0.1.0"
+    "@lblod/ember-rdfa-editor": "0.50.0-beta.4"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ember-concurrency": "2.x",
     "@appuniversum/appuniversum": "^0.2.1",
     "@appuniversum/ember-appuniversum": "^0.7.0",
-    "@lblod/ember-rdfa-editor": "0.50.0-beta.4"
+    "@lblod/ember-rdfa-editor": "^0.50.0-beta.5"
   },
   "devDependencies": {
     "@appuniversum/appuniversum": "^0.2.1",
@@ -52,6 +52,7 @@
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "@lblod/ember-rdfa-editor-besluit-plugin": "~0.1.0",
+    "@lblod/ember-rdfa-editor": "^0.50.0-beta.5",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~3.24.0",
@@ -90,8 +91,7 @@
     "qunit-dom": "^1.6.0",
     "sass": "^1.39.0",
     "webpack": "^5.58.2",
-    "xml-formatter": "^2.5.0",
-    "@lblod/ember-rdfa-editor": "0.50.0-beta.4"
+    "xml-formatter": "^2.5.0"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,10 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import xmlFormat from 'xml-formatter';
-import { basicSetup, EditorState, EditorView } from '@codemirror/basic-setup';
-import { xml } from '@codemirror/lang-xml';
-import { html } from '@codemirror/lang-html';
 
 export default class ApplicationController extends Controller {
   plugins = ['roadsign-regulation', 'besluit'];

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -7,119 +7,9 @@ import { xml } from '@codemirror/lang-xml';
 import { html } from '@codemirror/lang-html';
 
 export default class ApplicationController extends Controller {
-  @tracked debug;
-  @tracked xmlDebuggerOpen = false;
-  @tracked debuggerContent = '';
-  @tracked htmlDebuggerOpen = false;
-  unloadListener;
-  xmlEditor;
-  htmlEditor;
   plugins = ['roadsign-regulation', 'besluit'];
-  controller;
 
-  @tracked _editorController;
-
-  get editorController() {
-    if (!this._editorController) {
-      throw new Error('Accessing controller before editor init');
-    }
-    return this._editorController;
-  }
-
-  get formattedXmlContent() {
-    if (this.debuggerContent) {
-      try {
-        return xmlFormat(this.debuggerContent);
-      } catch (e) {
-        return this.debuggerContent;
-      }
-    }
-    return this.debuggerContent;
-  }
-
-  setup() {
-    this.unloadListener = () => {
-      this.saveEditorContentToLocalStorage();
-    };
-    window.addEventListener('beforeunload', this.unloadListener);
-  }
-
-  teardown() {
-    if (this.unloadListener) {
-      window.removeEventListener('beforeunload', this.unloadListener);
-    }
-  }
-
-  @action
-  initDebug(info) {
-    this.debug = info;
-  }
-
-  @action
-  setupXmlEditor(element) {
-    this.xmlEditor = new EditorView({
-      state: EditorState.create({
-        extensions: [basicSetup, xml()],
-      }),
-      parent: element,
-    });
-    this.xmlEditor.dispatch({
-      changes: { from: 0, insert: this.debuggerContent },
-    });
-  }
-
-  @action
-  setupHtmlEditor(element) {
-    this.htmlEditor = new EditorView({
-      state: EditorState.create({
-        extensions: [basicSetup, html()],
-      }),
-      parent: element,
-    });
-    this.htmlEditor.dispatch({
-      changes: { from: 0, insert: this.debuggerContent },
-    });
-  }
-
-  setHtmlContent(content) {
-    this.editorController.executeCommand(
-      'insert-html',
-      content,
-      this.editorController.rangeFactory.fromAroundAll()
-    );
-  }
-
-  setXmlContent(content) {
-    this.editorController.executeCommand(
-      'insert-xml',
-      content,
-      this.editorController.rangeFactory.fromAroundAll()
-    );
-  }
-
-  getXmlContent() {
-    const content = this.editorController.executeQuery(
-      'get-content',
-      'xml',
-      this.editorController.rangeFactory.fromAroundAll()
-    );
-    if (!content) {
-      return '';
-    }
-    return xmlFormat(content.innerHTML);
-  }
-
-  getHtmlContent() {
-    const content = this.editorController.executeQuery(
-      'get-content',
-      'html',
-      this.editorController.rangeFactory.fromAroundAll()
-    );
-    if (!content) {
-      return '';
-    }
-    return content.innerHTML;
-  }
+  @tracked rdfaEditor;
 
   @action
   rdfaEditorInit(controller) {
@@ -168,65 +58,9 @@ export default class ApplicationController extends Controller {
       <br>
     </div>
    </div>`;
-    this._editorController = controller;
-    this.setHtmlContent(presetContent);
+    this.rdfaEditor = controller;
+    this.rdfaEditor.setHtmlContent(presetContent);
     const editorDone = new CustomEvent('editor-done');
     window.dispatchEvent(editorDone);
-  }
-
-  @action
-  setDebuggerContent(content) {
-    this.debuggerContent = content;
-  }
-
-  @action
-  setEditorContent(type, content) {
-    if (this._editorController) {
-      if (type === 'html') {
-        this.setHtmlContent(content);
-        this.saveEditorContentToLocalStorage();
-      } else {
-        this.setXmlContent(content);
-        this.saveEditorContentToLocalStorage();
-      }
-    }
-  }
-
-  @action openContentDebugger(type) {
-    if (this._editorController) {
-      if (type === 'xml') {
-        this.debuggerContent = this.getXmlContent();
-        this.xmlDebuggerOpen = true;
-      } else {
-        this.debuggerContent = this.getHtmlContent();
-        this.htmlDebuggerOpen = true;
-      }
-    }
-  }
-
-  @action closeContentDebugger(type, save) {
-    if (type === 'xml') {
-      this.debuggerContent = this.xmlEditor.state.sliceDoc();
-      this.xmlDebuggerOpen = false;
-    } else {
-      this.debuggerContent = this.htmlEditor.state.sliceDoc();
-      this.htmlDebuggerOpen = false;
-    }
-    if (save) {
-      const content = this.debuggerContent;
-      if (!content) {
-        //xml parser doesn't accept an empty string
-        this.setEditorContent('html', '');
-      } else {
-        this.setEditorContent(type, content);
-      }
-    }
-  }
-
-  saveEditorContentToLocalStorage() {
-    if (this._editorController) {
-      const content = this.getHtmlContent();
-      localStorage.setItem('EDITOR_CONTENT', content || '');
-    }
   }
 }

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,11 +1,8 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
 
 export default class ApplicationController extends Controller {
   plugins = ['roadsign-regulation', 'besluit'];
-
-  @tracked rdfaEditor;
 
   @action
   rdfaEditorInit(controller) {
@@ -54,8 +51,7 @@ export default class ApplicationController extends Controller {
       <br>
     </div>
    </div>`;
-    this.rdfaEditor = controller;
-    this.rdfaEditor.setHtmlContent(presetContent);
+    controller.setHtmlContent(presetContent);
     const editorDone = new CustomEvent('editor-done');
     window.dispatchEvent(editorDone);
   }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -3,7 +3,6 @@
 <h1>Dummy app - roadsign-regulation-plugin</h1>
 
 <Rdfa::RdfaEditorWithDebug
-  class="rdfa-playground"
   @rdfaEditorInit={{this.rdfaEditorInit}}
   @plugins={{this.plugins}}
   @editorOptions={{hash

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,63 +1,24 @@
 {{page-title "roadsign-regulation-plugin"}}
 
-<div class="c-dummy">
-  <div class="c-dummy__header">
-    <h1>Dummy app - roadsign-regulation-plugin</h1>
-    {{#if this._editorController}}
-      <p>Sample data:
-        <button type="button" {{on "click" (fn this.setEditorContent "html" "")}}>Empty</button>
-        |
-        <button type="button" {{on "click" (fn this.openContentDebugger "html")}}>CustomHTML</button>
-        |
-        <button type="button" {{on "click" (fn this.openContentDebugger "xml")}}>CustomXML</button>
-      </p>
-    {{else}}
-      Waiting for editor init
-    {{/if}}
-  </div>
-  <div class="c-dummy__content">
-    <div vocab="http://data.vlaanderen.be/ns/foo#" resource="#Foo" typeof="Foo">
-      <div vocab="http://data.vlaanderen.be/ns/besluit#"
-           prefix="ext:http://mu.semte.ch/vocabularies/ext/ eli: http://data.europa.eu/eli/ontology# prov: http://www.w3.org/ns/prov# mandaat: http://data.vlaanderen.be/ns/mandaat# besluit: http://data.vlaanderen.be/ns/besluit#"
-           typeof="besluit:BehandelingVanAgendapunt"
-           class="app-view">
+<h1>Dummy app - roadsign-regulation-plugin</h1>
 
-        <Rdfa::RdfaEditor
-          @rdfaEditorInit={{this.rdfaEditorInit}}
-          class="rdfa-playground"
-          @plugins={{this.plugins}}
-          @editorOptions={{hash showToggleRdfaAnnotations="true" showInsertButton=null showRdfa="true" showRdfaHighlight="true" showRdfaHover="true" showPaper="true" showLeft="true" showSidebar="true"}}
-          @toolbarOptions={{hash showTextStyleButtons="true" showListButtons="true" showIndentButtons="true"}}
-        />
-      </div>
-    </div>
-  </div>
-</div>
-{{#if this.xmlDebuggerOpen}}
-  <div class="rdfa-debugger-panel-wrapper">
-    <div class="rdfa-debugger-content">
-      <h1>XML representation</h1>
-      <button type="button" {{on "click" (fn this.closeContentDebugger "xml" true)}}>Set Xml</button>
-      <button type="button" {{on "click" (fn this.closeContentDebugger "xml" false)}}>Cancel</button>
-      <hr>
-      <div class="rdfa-debugger-textarea-wrapper">
-        <div>Enter xml here</div>
-        <div {{did-insert this.setupXmlEditor}}></div>
-      </div>
-    </div>
-  </div>
-{{/if}}
-{{#if this.htmlDebuggerOpen}}
-  <div class="rdfa-debugger-panel-wrapper">
-    <div class="rdfa-debugger-content">
-      <h1>HTML representation</h1>
-      <button type="button" {{on "click" (fn this.closeContentDebugger "html" true)}}>Set HTML</button>
-      <button type="button" {{on "click" (fn this.closeContentDebugger "html" false)}}>Cancel</button>
-      <hr>
-      <div class="rdfa-debugger-textarea-wrapper">
-        <div>Enter html here</div>
-        <div {{did-insert this.setupHtmlEditor}}></div>
-      </div>
-    </div>
-  </div>
-{{/if}}
+<Rdfa::RdfaEditorWithDebug
+  class="rdfa-playground"
+  @rdfaEditorInit={{this.rdfaEditorInit}}
+  @plugins={{this.plugins}}
+  @editorOptions={{hash
+    showToggleRdfaAnnotations="true"
+    showInsertButton=null
+    showRdfa="true"
+    showRdfaHighlight="true"
+    showRdfaHover="true"
+    showPaper="true"
+    showLeft="true"
+    showSidebar="true"
+  }}
+  @toolbarOptions={{hash
+    showTextStyleButtons="true"
+    showListButtons="true"
+    showIndentButtons="true"
+  }}
+/>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,6 +1,5 @@
 {{page-title "roadsign-regulation-plugin"}}
 
-<h1>Dummy app - roadsign-regulation-plugin</h1>
 
 <Rdfa::RdfaEditorWithDebug
   @rdfaEditorInit={{this.rdfaEditorInit}}
@@ -19,5 +18,6 @@
     showTextStyleButtons="true"
     showListButtons="true"
     showIndentButtons="true"
-  }}
-/>
+  }}>
+  <h1>Dummy app - roadsign-regulation-plugin</h1>
+</Rdfa::RdfaEditorWithDebug>


### PR DESCRIPTION
This plugin now uses the debug component from the ember-rdfa-editor instead of duplicating code. As of now this depends on release 0.50.0-beta.5 of the editor.
Was tested, but please, test the build and its dependencies as a double check.