### PR TITLE
Explicit import debug component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lblod/ember-rdfa-editor-roadsign-regulation-plugin",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ember-concurrency": "2.x",
     "@appuniversum/appuniversum": "^0.2.1",
     "@appuniversum/ember-appuniversum": "^0.7.0",
-    "@lblod/ember-rdfa-editor": "^0.50.0-beta.7"
+    "@lblod/ember-rdfa-editor": "^0.50.0-beta.8"
   },
   "devDependencies": {
     "@appuniversum/appuniversum": "^0.2.1",
@@ -52,7 +52,7 @@
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "@lblod/ember-rdfa-editor-besluit-plugin": "~0.1.0",
-    "@lblod/ember-rdfa-editor": "^0.50.0-beta.7",
+    "@lblod/ember-rdfa-editor": "^0.50.0-beta.8",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~3.24.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ember-concurrency": "2.x",
     "@appuniversum/appuniversum": "^0.2.1",
     "@appuniversum/ember-appuniversum": "^0.7.0",
-    "@lblod/ember-rdfa-editor": "^0.50.0-beta.8"
+    "@lblod/ember-rdfa-editor": "^0.50.0-beta.7"
   },
   "devDependencies": {
     "@appuniversum/appuniversum": "^0.2.1",
@@ -52,7 +52,7 @@
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "@lblod/ember-rdfa-editor-besluit-plugin": "~0.1.0",
-    "@lblod/ember-rdfa-editor": "^0.50.0-beta.8",
+    "@lblod/ember-rdfa-editor": "^0.50.0-beta.7",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~3.24.0",

--- a/tests/dummy/app/components/rdfa-editor-with-debug.js
+++ b/tests/dummy/app/components/rdfa-editor-with-debug.js
@@ -1,0 +1,1 @@
+export {default} from "@lblod/ember-rdfa-editor/components/rdfa/rdfa-editor-with-debug";

--- a/tests/dummy/app/components/rdfa-editor-with-debug.js
+++ b/tests/dummy/app/components/rdfa-editor-with-debug.js
@@ -1,1 +1,1 @@
-export {default} from "@lblod/ember-rdfa-editor/components/rdfa/rdfa-editor-with-debug";
+export { default } from '@lblod/ember-rdfa-editor/components/rdfa/rdfa-editor-with-debug';

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,7 +1,7 @@
 {{page-title "roadsign-regulation-plugin"}}
 
 
-<Rdfa::RdfaEditorWithDebug
+<RdfaEditorWithDebug
   @rdfaEditorInit={{this.rdfaEditorInit}}
   @plugins={{this.plugins}}
   @editorOptions={{hash
@@ -20,4 +20,4 @@
     showIndentButtons="true"
   }}>
   <h1>Dummy app - roadsign-regulation-plugin</h1>
-</Rdfa::RdfaEditorWithDebug>
+</RdfaEditorWithDebug>


### PR DESCRIPTION
Due to the export of the debug component in the editor, the consuming app also imports modules only related to the debug component for no reason. The solution was to not export the debug component. The plugins that want to use the debug component need to explicitely import it first. This PR does that. Explicit importing is needed for ember-rdfa-editor v0.50.0-beta.8 and onwards, but the explicit import won't break on older editor versions.