### PR TITLE
Remove broken and unneeded modelwritten handler

### DIFF
--- a/addon/roadsign-regulation-plugin.js
+++ b/addon/roadsign-regulation-plugin.js
@@ -1,32 +1,18 @@
 /**
- * Entry point for RoadsignRegulation
- *
- * @module editor-roadsign-regulation-plugin
- * @class RoadSignRegulationPlugin
- * @constructor
- * @extends EmberService
+ * Entrypoint for the roadsign regulation plugin.
  */
 export default class RoadSignRegulationPlugin {
-  /**
-   * Handles the incoming events from the editor dispatcher.  Responsible for generating hint cards.
-   *
-   * @method execute
-   *
-   * @param {string} hrId Unique identifier of the state in the HintsRegistry.  Allows the
-   * HintsRegistry to update absolute selected regions based on what a user has entered in between.
-   * @param {Array} rdfaBlocks Set of logical blobs of content which may have changed.  Each blob is
-   * either has a different semantic meaning, or is logically separated (eg: a separate list item).
-   * @param {Object} hintsRegistry Keeps track of where hints are positioned in the editor.
-   * @param {Object} editor Your public interface through which you can alter the document.
-   *
-   * @public
-   */
   controller;
 
   get name() {
     return 'roadsign-regulation';
   }
 
+  /**
+   * Gets called when the editor loads.
+   * Can optionally be async if needed.
+   * @param controller
+   */
   initialize(controller) {
     this.controller = controller;
     controller.registerWidget({

--- a/addon/roadsign-regulation-plugin.js
+++ b/addon/roadsign-regulation-plugin.js
@@ -34,22 +34,5 @@ export default class RoadSignRegulationPlugin {
       identifier: 'roadsign-regulation-plugin/card',
       desiredLocation: 'insertSidebar',
     });
-    controller.onEvent('modelWritten', this.modelWrittenHandler.bind(this));
-  }
-
-  modelWrittenHandler(event) {
-    if (event.owner !== this.name) {
-      const rangesToHighlight = this.controller.executeCommand(
-        'match-text',
-        this.controller.createFullDocumentRange(),
-        /roadsign/g
-      );
-
-      for (const range of rangesToHighlight) {
-        const selection = this.controller.createSelection();
-        selection.selectRange(range);
-        this.controller.executeCommand('make-highlight', selection, false);
-      }
-    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@ember/test-helpers": "^2.6.0",
         "@glimmer/component": "^1.0.4",
         "@glimmer/tracking": "^1.0.4",
-        "@lblod/ember-rdfa-editor": "0.63.1",
+        "@lblod/ember-rdfa-editor": "^0.63.1",
         "@lblod/ember-rdfa-editor-besluit-plugin": "~0.5.0",
         "babel-eslint": "^10.1.0",
         "broccoli-asset-rev": "^3.0.0",
@@ -67,7 +67,7 @@
       },
       "peerDependencies": {
         "@appuniversum/ember-appuniversum": "^1.5.0",
-        "@lblod/ember-rdfa-editor": "0.63.1",
+        "@lblod/ember-rdfa-editor": "^0.63.1",
         "ember-concurrency": "2.x"
       }
     },


### PR DESCRIPTION
Removes the unnecessary handler. It uses controller methods that don't exist anymore which make the editor crash. It was only fine before editor v0.63.3 because the modelWritten event was simply never emitted.
